### PR TITLE
fix(vk-2): add NULL sentinel to PipelineHandle

### DIFF
--- a/khaos-core/src/jvmMain/kotlin/khaos/vulkan/PipelineHandle.kt
+++ b/khaos-core/src/jvmMain/kotlin/khaos/vulkan/PipelineHandle.kt
@@ -12,4 +12,17 @@ package khaos.vulkan
  *
  * Cost: one heap allocation per instance that the other inline handle types avoid.
  */
-data class PipelineHandle(val handle: Long, val reusable: Boolean)
+data class PipelineHandle(val handle: Long, val reusable: Boolean) {
+    companion object {
+        /**
+         * The absent pipeline — `VK_NULL_HANDLE`, matching the `NULL` constant every other handle
+         * type exposes. Use it instead of a nullable `PipelineHandle?` so the absent case stays in
+         * the type rather than in every call site's null check.
+         *
+         * `reusable` is `false` because reuse is a promise about a real pipeline object surviving
+         * across draws. There is no object here to survive, and declaring the null handle reusable
+         * would let a multi-draw path accept it as a legitimate binding.
+         */
+        val NULL = PipelineHandle(handle = 0L, reusable = false)
+    }
+}

--- a/khaos-core/src/jvmTest/kotlin/khaos/vulkan/HandleSpec.kt
+++ b/khaos-core/src/jvmTest/kotlin/khaos/vulkan/HandleSpec.kt
@@ -176,6 +176,32 @@ class HandleSpec : FreeSpec({
         }
     }
 
+    "AC4-P4: PipelineHandle.NULL has handle value 0L and is not reusable" {
+        PipelineHandle.NULL.handle shouldBe 0L
+        // A sentinel standing for "no pipeline" must not claim it survives across draws.
+        PipelineHandle.NULL.reusable shouldBe false
+    }
+
+    "AC4-P5: every handle type exposes a NULL sentinel — including the non-inline PipelineHandle" {
+        // AC4-P3 walks only the inline types. PipelineHandle is a data class and would slip
+        // through that loop, which is exactly how it went without a sentinel until now.
+        val allHandleClasses = allInlineHandleClasses + PipelineHandle::class
+        for (klass in allHandleClasses) {
+            val companion = klass.companionObjectInstance
+                ?: error("${klass.simpleName} has no companion object — AC4 requires a NULL sentinel")
+            val companionKlass = klass.companionObject
+                ?: error("${klass.simpleName} has no companion KClass")
+            val nullValue = companionKlass.memberProperties
+                .firstOrNull { it.name == "NULL" }
+                ?.getter?.call(companion)
+                ?: error("${klass.simpleName} exposes no NULL constant")
+            val handleValue = klass.memberProperties
+                .first { it.name == "handle" }
+                .getter.call(nullValue)
+            handleValue shouldBe 0L
+        }
+    }
+
     "AC4-N1 (negative): directly constructing InstanceHandle(0L) fails to compile" {
         val compilation = KotlinCompilation().apply {
             sources = listOf(SourceFile.kotlin("DirectConstruct.kt", """


### PR DESCRIPTION
Closes the one unmet acceptance criterion noted when #6 was closed.

## The gap

AC4 of #6 asks for a typed sentinel on every handle type. All 18 `@JvmInline` handles expose `NULL`; `PipelineHandle` did not. It went unnoticed because `AC4-P3` iterates `allInlineHandleClasses` — `PipelineHandle` is a data class (it carries `reusable` alongside the handle) and was never in that list.

## `reusable = false`

Reuse is a promise about a real pipeline object surviving across draws. There is no object here to survive, and a `reusable = true` null handle could be accepted by a multi-draw path as a legitimate binding. `false` is the conservative reading and is documented on the constant.

## Tests

- **AC4-P4** asserts `handle == 0L` and `reusable == false` directly.
- **AC4-P5** walks *every* handle type, inline and not, so adding a future handle without a sentinel fails rather than silently sitting outside the loop — the exact way this one was missed.

Both verified to fail when the sentinel is removed: P4 at compile time, P5 with `PipelineHandle exposes no NULL constant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)